### PR TITLE
feat: GET /json_db - endpoint para listar JSONs disponíveis (manifest)

### DIFF
--- a/app/Http/Controllers/DatabaseJsonController.php
+++ b/app/Http/Controllers/DatabaseJsonController.php
@@ -2,12 +2,49 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Support\Facades\File;
+
 class DatabaseJsonController extends Controller
 {
     public function __construct()
     {
         ini_set('memory_limit', '-1');
         set_time_limit(60 * 60);
+    }
+
+    /**
+     * Lista todos os arquivos JSON disponiveis para download.
+     * Retorna nome (sem extensao) e tamanho em bytes de cada arquivo.
+     */
+    public function manifest()
+    {
+        $dir = base_path('public/db/json/');
+
+        if (!File::exists($dir)) {
+            return response()->json([
+                'files' => [],
+                'total' => 0,
+            ]);
+        }
+
+        $files = File::files($dir);
+        $result = [];
+
+        foreach ($files as $file) {
+            if ($file->getExtension() !== 'json') {
+                continue;
+            }
+
+            $result[] = [
+                'name' => $file->getBasename('.json'),
+                'size' => $file->getSize(),
+            ];
+        }
+
+        return response()->json([
+            'files' => $result,
+            'total' => count($result),
+        ]);
     }
 
     public function index($file)

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,7 @@ $router->group(['middleware' => 'general'], function () use ($router) {
 
     $router->get('/player', 'PlayerController@index');
 
+    $router->get('/json_db', 'DatabaseJsonController@manifest');
     $router->get('/json_db/{file}', 'DatabaseJsonController@index');
 
     $router->get('/download', 'DownloadController@index');


### PR DESCRIPTION
## Problema

Atualmente não existe um endpoint que liste quais arquivos JSON estão disponíveis para download. O frontend (e o app Electron/desktop) precisa saber quais arquivos existem em `public/db/json/` sem precisar chutar nomes ou fazer múltiplas requisições tentando nomes diferentes.

## Solução

Adiciona `GET /json_db` (sem parâmetro) que retorna um manifest com todos os arquivos `.json` disponíveis:

```json
{
  "files": [
    { "name": "config", "size": 123 },
    { "name": "pt_musics", "size": 456789 },
    { "name": "pt_categories", "size": 12345 },
    { "name": "music_1", "size": 2345 },
    ...
  ],
  "total": 42
}
```

O cliente itera sobre `files` e baixa cada um via `GET /json_db/{name}` (já existente).

## Mudanças

- `DatabaseJsonController.php`: novo método `manifest()` que escaneia `public/db/json/`
- `routes/web.php`: adicionada rota `GET /json_db` antes da rota existente `GET /json_db/{file}`

## Compatibilidade

- Não altera nenhum endpoint existente
- `GET /json_db/{file}` continua funcionando igual
- PR minimalista: 2 arquivos, +38 linhas