### PR TITLE
feat(export): endpoints de export JSON com cache e paginação

### DIFF
--- a/app/Http/Controllers/DatabaseJsonController.php
+++ b/app/Http/Controllers/DatabaseJsonController.php
@@ -2,6 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+use OpenApi\Attributes as OA;
+
 class DatabaseJsonController extends Controller
 {
     public function __construct()
@@ -10,6 +15,239 @@ class DatabaseJsonController extends Controller
         set_time_limit(60 * 60);
     }
 
+    /**
+     * Retorna o manifest de arquivos JSON disponíveis.
+     * Cache por 1 hora (3600s) para evitar leitura repetida do disco.
+     */
+    #[OA\Get(
+        path: '/db/manifest',
+        summary: 'Manifest de arquivos JSON',
+        description: 'Lista todos os arquivos JSON disponíveis em public/db/json com nome, tabela e path de acesso.',
+        tags: ['Database'],
+        security: [['ApiToken' => []]],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Lista de arquivos JSON disponíveis',
+                content: new OA\JsonContent(
+                    type: 'array',
+                    items: new OA\Items(
+                        type: 'object',
+                        properties: [
+                            new OA\Property(property: 'file', type: 'string', example: 'config.json'),
+                            new OA\Property(property: 'table', type: 'string', example: 'config'),
+                            new OA\Property(property: 'path', type: 'string', example: '/db/config'),
+                        ]
+                    )
+                )
+            )
+        ]
+    )]
+    public function manifest()
+    {
+        return Cache::remember('db.manifest', 3600, function () {
+            $jsonDir = base_path('public/db/json');
+            $files = [];
+            if (File::exists($jsonDir)) {
+                foreach (File::files($jsonDir) as $file) {
+                    $files[] = [
+                        'file' => $file->getFilename(),
+                        'table' => $file->getFilenameWithoutExtension(),
+                        'path' => '/db/' . $file->getFilenameWithoutExtension(),
+                    ];
+                }
+            }
+            return $files;
+        });
+    }
+
+    /**
+     * Retorna todos os registros de uma tabela (arquivo JSON).
+     * Suporta paginação via ?page=1&per_page=50
+     * Cache por 5 minutos (300s) por página.
+     */
+    #[OA\Get(
+        path: '/db/{table}',
+        summary: 'Registros de uma tabela JSON',
+        description: 'Retorna registros paginados de um arquivo JSON específico. Suporta paginação via query params.',
+        tags: ['Database'],
+        security: [['ApiToken' => []]],
+        parameters: [
+            new OA\Parameter(
+                name: 'table',
+                in: 'path',
+                required: true,
+                schema: new OA\Schema(type: 'string'),
+                description: 'Nome da tabela (arquivo JSON sem extensão)'
+            ),
+            new OA\Parameter(
+                name: 'page',
+                in: 'query',
+                schema: new OA\Schema(type: 'integer', default: 1),
+                description: 'Número da página'
+            ),
+            new OA\Parameter(
+                name: 'per_page',
+                in: 'query',
+                schema: new OA\Schema(type: 'integer', default: 50),
+                description: 'Itens por página'
+            )
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Registros paginados',
+                content: new OA\JsonContent(
+                    type: 'object',
+                    properties: [
+                        new OA\Property(
+                            property: 'data',
+                            type: 'array',
+                            items: new OA\Items(type: 'object')
+                        ),
+                        new OA\Property(
+                            property: 'meta',
+                            type: 'object',
+                            properties: [
+                                new OA\Property(property: 'total', type: 'integer', example: 100),
+                                new OA\Property(property: 'per_page', type: 'integer', example: 50),
+                                new OA\Property(property: 'current_page', type: 'integer', example: 1),
+                                new OA\Property(property: 'last_page', type: 'integer', example: 2),
+                            ]
+                        ),
+                    ]
+                )
+            ),
+            new OA\Response(response: 404, description: 'Arquivo não encontrado')
+        ]
+    )]
+    public function table(Request $request, string $table)
+    {
+        $cacheKey = "db.table.{$table}.page.{$request->get('page', 1)}.per_page.{$request->get('per_page', 50)}";
+
+        return Cache::remember($cacheKey, 300, function () use ($request, $table) {
+            $jsonDir = base_path('public/db/json');
+            $filePath = "{$jsonDir}/{$table}.json";
+
+            if (!File::exists($filePath)) {
+                return response()->json(['error' => 'Table not found'], 404);
+            }
+
+            $data = json_decode(File::get($filePath), true);
+
+            $perPage = (int) $request->get('per_page', 50);
+            $page = (int) $request->get('page', 1);
+            $total = count($data);
+            $offset = ($page - 1) * $perPage;
+            $items = array_slice($data, $offset, $perPage);
+
+            return response()->json([
+                'data' => $items,
+                'meta' => [
+                    'total' => $total,
+                    'per_page' => $perPage,
+                    'current_page' => $page,
+                    'last_page' => (int) ceil($total / $perPage),
+                ]
+            ]);
+        });
+    }
+
+    /**
+     * Exporta categorias únicas de uma tabela/coluna.
+     * Cache por 10 minutos (600s).
+     */
+    #[OA\Get(
+        path: '/db/{table}/categories',
+        summary: 'Categorias únicas de uma coluna',
+        description: 'Retorna array de valores únicos de uma coluna específica em um arquivo JSON, ordenados alfabeticamente.',
+        tags: ['Database'],
+        security: [['ApiToken' => []]],
+        parameters: [
+            new OA\Parameter(
+                name: 'table',
+                in: 'path',
+                required: true,
+                schema: new OA\Schema(type: 'string'),
+                description: 'Nome da tabela'
+            ),
+            new OA\Parameter(
+                name: 'column',
+                in: 'query',
+                required: true,
+                schema: new OA\Schema(type: 'string'),
+                description: 'Nome da coluna para extrair categorias únicas'
+            )
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Array de categorias únicas ordenadas',
+                content: new OA\JsonContent(
+                    type: 'array',
+                    items: new OA\Items(type: 'string')
+                )
+            ),
+            new OA\Response(response: 400, description: 'Parâmetro column obrigatório'),
+            new OA\Response(response: 404, description: 'Tabela não encontrada')
+        ]
+    )]
+    public function categories(Request $request, string $table)
+    {
+        $column = $request->get('column');
+        if (!$column) {
+            return response()->json(['error' => 'Parâmetro column é obrigatório'], 400);
+        }
+
+        $cacheKey = "db.categories.{$table}.column.{$column}";
+
+        return Cache::remember($cacheKey, 600, function () use ($table, $column) {
+            $jsonDir = base_path('public/db/json');
+            $filePath = "{$jsonDir}/{$table}.json";
+
+            if (!File::exists($filePath)) {
+                return response()->json(['error' => 'Table not found'], 404);
+            }
+
+            $data = json_decode(File::get($filePath), true);
+
+            $categories = [];
+            foreach ($data as $row) {
+                if (isset($row[$column]) && $row[$column] !== null && $row[$column] !== '') {
+                    $categories[$row[$column]] = true;
+                }
+            }
+
+            $categories = array_keys($categories);
+            sort($categories);
+
+            return response()->json($categories);
+        });
+    }
+
+    /**
+     * Obter arquivo JSON exportado (endpoint legado).
+     */
+    #[OA\Get(
+        path: '/json_db/{file}',
+        summary: 'Obter arquivo JSON exportado (legado)',
+        description: 'Retorna o conteúdo de um arquivo JSON específico da pasta public/db/json/',
+        tags: ['Database'],
+        security: [['ApiToken' => []]],
+        parameters: [
+            new OA\Parameter(
+                name: 'file',
+                description: 'Nome do arquivo (sem extensão .json)',
+                in: 'path',
+                required: true,
+                schema: new OA\Schema(type: 'string', example: 'config')
+            )
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'Conteúdo do JSON'),
+            new OA\Response(response: 404, description: 'Arquivo não encontrado'),
+        ]
+    )]
     public function index($file)
     {
         $file = $file . ".json";

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,10 @@
         "psr-4": {
             "App\\": "app/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="bootstrap/app.php"
          colors="true"
 >
     <testsuites>
         <testsuite name="Application Test Suite">
-            <directory suffix="Test.php">./tests</directory>
+            <directory suffix="Test.php">./tests/Feature</directory>
+            <directory suffix="Test.php">./tests/Unit</directory>
+            <exclude>./tests/ExampleTest.php</exclude>
         </testsuite>
     </testsuites>
     <php>

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,9 @@ $router->group(['middleware' => 'general'], function () use ($router) {
     $router->get('/player', 'PlayerController@index');
 
     $router->get('/json_db/{file}', 'DatabaseJsonController@index');
+    $router->get('/db/manifest', 'DatabaseJsonController@manifest');
+    $router->get('/db/{table}', 'DatabaseJsonController@table');
+    $router->get('/db/{table}/categories', 'DatabaseJsonController@categories');
 
     $router->get('/download', 'DownloadController@index');
     $router->get('/version_log', 'VersionLogController@index');

--- a/tests/Feature/DatabaseJsonControllerExportTest.php
+++ b/tests/Feature/DatabaseJsonControllerExportTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+class DatabaseJsonControllerExportTest extends TestCase
+{
+    private string $jsonDir;
+    private string $testFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->jsonDir = base_path('public/db/json');
+        $this->testFile = $this->jsonDir . '/musics.json';
+
+        if (!File::isDirectory($this->jsonDir)) {
+            File::makeDirectory($this->jsonDir, 0755, true);
+        }
+
+        File::put($this->testFile, json_encode([
+            ['id' => 1, 'title' => 'Hino 1', 'category' => 'louvor', 'author' => 'Autor A'],
+            ['id' => 2, 'title' => 'Hino 2', 'category' => 'adoracao', 'author' => 'Autor B'],
+            ['id' => 3, 'title' => 'Hino 3', 'category' => 'louvor', 'author' => 'Autor A'],
+            ['id' => 4, 'title' => 'Hino 4', 'category' => '', 'author' => ''],
+            ['id' => 5, 'title' => 'Hino 5', 'category' => null, 'author' => null],
+        ], JSON_PRETTY_PRINT));
+    }
+
+    protected function tearDown(): void
+    {
+        if (File::exists($this->testFile)) {
+            File::delete($this->testFile);
+        }
+
+        parent::tearDown();
+    }
+
+    // ── Manifest ─────────────────────────────────────────────
+
+    public function test_manifest_returns_structure(): void
+    {
+        $this->get('/db/manifest');
+        $this->seeStatusCode(200);
+
+        $data = $this->response->json();
+        $this->assertIsArray($data);
+        $this->assertNotEmpty($data);
+
+        $entry = $data[0];
+        $this->assertArrayHasKey('file', $entry);
+        $this->assertArrayHasKey('table', $entry);
+        $this->assertArrayHasKey('path', $entry);
+
+        $musicEntry = collect($data)->first(fn ($e) => $e['table'] === 'musics');
+        $this->assertNotNull($musicEntry, 'musics deve estar no manifest');
+        $this->assertSame('musics.json', $musicEntry['file']);
+        $this->assertSame('/db/musics', $musicEntry['path']);
+    }
+
+    public function test_manifest_caches_response(): void
+    {
+        Cache::forget('db.manifest');
+
+        $this->get('/db/manifest');
+        $this->assertTrue(Cache::has('db.manifest'));
+
+        Cache::forget('db.manifest');
+    }
+
+    // ── Table (Paginated) ──────────────────────────────────────
+
+    public function test_table_returns_paginated_data(): void
+    {
+        $this->get('/db/musics');
+        $this->seeStatusCode(200);
+
+        $data = $this->response->json();
+
+        $this->assertArrayHasKey('data', $data);
+        $this->assertArrayHasKey('meta', $data);
+        $this->assertIsArray($data['data']);
+        $this->assertCount(5, $data['data']);
+
+        $this->assertEquals(5, $data['meta']['total']);
+        $this->assertEquals(50, $data['meta']['per_page']);
+        $this->assertEquals(1, $data['meta']['current_page']);
+        $this->assertEquals(1, $data['meta']['last_page']);
+    }
+
+    public function test_table_respects_page_parameter(): void
+    {
+        $this->get('/db/musics?page=1&per_page=2');
+        $this->seeStatusCode(200);
+
+        $data = $this->response->json();
+
+        $this->assertCount(2, $data['data']);
+        $this->assertEquals(5, $data['meta']['total']);
+        $this->assertEquals(2, $data['meta']['per_page']);
+        $this->assertEquals(1, $data['meta']['current_page']);
+        $this->assertEquals(3, $data['meta']['last_page']);
+    }
+
+    public function test_table_caches_response(): void
+    {
+        Cache::flush();
+
+        $this->get('/db/musics?page=1&per_page=50');
+        $this->assertTrue(Cache::has('db.table.musics.page.1.per_page.50'));
+
+        Cache::flush();
+    }
+
+    // ── Categories ─────────────────────────────────────────────
+
+    public function test_categories_returns_unique_values(): void
+    {
+        $this->get('/db/musics/categories?column=category');
+        $this->seeStatusCode(200);
+
+        $categories = $this->response->json();
+        $this->assertIsArray($categories);
+        $this->assertContains('louvor', $categories);
+        $this->assertContains('adoracao', $categories);
+        $this->assertNotContains('', $categories);
+        $this->assertNotContains(null, $categories);
+    }
+
+    public function test_categories_filters_empty_values(): void
+    {
+        $this->get('/db/musics/categories?column=author');
+        $this->seeStatusCode(200);
+
+        $authors = $this->response->json();
+        $this->assertIsArray($authors);
+        $this->assertContains('Autor A', $authors);
+        $this->assertContains('Autor B', $authors);
+        $this->assertNotContains('', $authors);
+        $this->assertNotContains(null, $authors);
+    }
+
+    public function test_categories_requires_column_parameter(): void
+    {
+        $this->get('/db/musics/categories');
+        $this->seeStatusCode(400);
+        $this->assertEquals('Parâmetro column é obrigatório', $this->response->json()['error']);
+    }
+
+    public function test_categories_returns_404_for_missing_file(): void
+    {
+        $this->get('/db/nonexistent/categories?column=title');
+        $this->seeStatusCode(404);
+        $this->assertEquals('Table not found', $this->response->json()['error']);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests;
+
 use Laravel\Lumen\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase


### PR DESCRIPTION
## Resumo

Endpoints de exportação de dados JSON com caching configurável e paginação.

## Endpoints

| Método | Rota | Descrição | Cache TTL |
|--------|------|-----------|-----------|
| GET | `/db/manifest` | Lista arquivos JSON disponíveis | 1h (3600s) |
| GET | `/db/{table}?page=1&per_page=50` | Registros paginados | 5min (300s) |
| GET | `/db/{table}/categories?column=nome` | Valores únicos de coluna | 10min (600s) |

## Detalhes

- **Cache**: Usa Laravel Cache facade (array em testes, Redis em prod)
- **Paginação**: array_slice nativo, default 50/page
- **Categories**: deduplicação via array keys, filtra null/empty
- **OpenAPI**: PHP 8 attributes em todos os endpoints (swagger-php)
- **Testes**: 9 testes PHPUnit, 42 assertions

## Arquivos modificados

- `app/Http/Controllers/DatabaseJsonController.php` — rewrite com manifest/table/categories
- `routes/web.php` — 3 novas rotas
- `tests/Feature/DatabaseJsonControllerExportTest.php` — 9 testes novos
- `tests/TestCase.php` — namespace PSR-4
- `phpunit.xml` — bootstrap Lumen + array cache
- `composer.json` — autoload-dev PSR-4

## Testes

```
9 tests, 42 assertions — OK
```