### PR TITLE
fix(security): SSL verify default true + unificar config entre services

### DIFF
--- a/app/Services/YoutubeService.php
+++ b/app/Services/YoutubeService.php
@@ -7,12 +7,10 @@ use GuzzleHttp\Client;
 class YoutubeService
 {
     protected $key;
-    protected $isLocalhost;
 
     public function __construct()
     {
         $this->key = config('api.youtube.key');
-        $this->isLocalhost = (request()->getHost() === 'localhost' || request()->getHost() === '127.0.0.1');
     }
 
     public function channel($id)
@@ -26,7 +24,7 @@ class YoutubeService
                     'id' => $id,
                     'key' => $this->key,
                 ],
-                'verify' => !$this->isLocalhost
+                'verify' => config('files.ssl_verify'),
             ]);
 
             $data = json_decode($response->getBody(), true);
@@ -53,7 +51,7 @@ class YoutubeService
                     'id' => $id,
                     'key' => $this->key,
                 ],
-                'verify' => !$this->isLocalhost
+                'verify' => config('files.ssl_verify'),
             ]);
 
             $data = json_decode($response->getBody(), true);
@@ -85,7 +83,7 @@ class YoutubeService
                         'maxResults' => 50,
                         'pageToken' => $pageToken,
                     ],
-                    'verify' => !$this->isLocalhost
+                    'verify' => config('files.ssl_verify'),
                 ]);
 
                 $data = json_decode($response->getBody(), true);

--- a/config/files.php
+++ b/config/files.php
@@ -26,6 +26,6 @@ return [
     |
     */
 
-    'ssl_verify' => env('SSL_VERIFY', false),
+    'ssl_verify' => env('SSL_VERIFY', true),
 
 ];


### PR DESCRIPTION
## Problema

- `config/files.php` defaultava `ssl_verify` para `false` — em produção, SSL ficava desativado se ninguém setasse `SSL_VERIFY=true` no `.env`
- `TelegramService` já usava `config('files.ssl_verify')` mas `YoutubeService` usava um hack de `isLocalhost` (comparação de host no construtor), inconsistente com o resto do código

## Mudanças

1. **config/files.php**: `env('SSL_VERIFY', false)` → `env('SSL_VERIFY', true)` — produção segura por padrão
2. **YoutubeService**: substitui `!->isLocalhost` por `config('files.ssl_verify')` em todos os 3 métodos (channel, playlist, playlistItems)
3. Remove propriedade `isLocalhost` e lógica de detecção do construtor

## Comportamento

- **Produção**: SSL verificado por padrão (seguro)
- **Desenvolvimento local**: setar `SSL_VERIFY=false` no `.env`
- Ambos services agora usam a mesma fonte de configuração

## Testes

27/27 passando (PHPUnit, SQLite in-memory)