### PR TITLE
fix: remove dead code em Data helper

### DIFF
--- a/app/Helpers/Data.php
+++ b/app/Helpers/Data.php
@@ -31,8 +31,6 @@ class Data
                 $data->where(DB::raw($field), $we['op'], $we['value']);
             }
         }
-        //echo PHP_EOL . $data->toSql();
-        //dd($data->toSql());
         return $data->paginate($request->limit);
     }
 


### PR DESCRIPTION
Remove 2 linhas comentadas de debug (`//echo $data->toSql()` e `//dd()`) do `app/Helpers/Data.php`.

Código de debug não deveria estar em produção, mesmo comentado.

27/27 testes passando.