### PR TITLE
feat: add /version endpoint para clientes

### DIFF
--- a/app/Http/Controllers/VersionController.php
+++ b/app/Http/Controllers/VersionController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+class VersionController extends Controller
+{
+    /**
+     * Returns API version information for client compatibility checks.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function index()
+    {
+        return response()->json([
+            'api_version' => config('version.version'),
+            'min_client_version' => config('version.min_client_version'),
+            'php_version' => PHP_VERSION,
+            'lumen_version' => app()->version(),
+        ]);
+    }
+}

--- a/config/version.php
+++ b/config/version.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | API Version
+    |--------------------------------------------------------------------------
+    |
+    | API version and minimum client version for compatibility checks.
+    | Clients can query GET /version to determine if they are compatible.
+    |
+    */
+
+    'version' => env('API_VERSION', '1.0.0'),
+    'min_client_version' => env('API_MIN_CLIENT_VERSION', '1.0.0'),
+
+];

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,6 +27,7 @@ $router->group(['middleware' => 'general'], function () use ($router) {
     $router->get('/json_db/{file}', 'DatabaseJsonController@index');
 
     $router->get('/download', 'DownloadController@index');
+    $router->get('/version', 'VersionController@index');
     $router->get('/version_log', 'VersionLogController@index');
 
     $router->group(['middleware' => 'api'], function () use ($router) {

--- a/tests/Feature/VersionEndpointQuickTest.php
+++ b/tests/Feature/VersionEndpointQuickTest.php
@@ -1,0 +1,32 @@
+
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class VersionEndpointTest extends TestCase
+{
+    public function testVersionEndpointReturns200()
+    {
+        $this->get(/version);
+        $this->seeStatusCode(200);
+    }
+
+    public function testVersionEndpointReturnsJsonStructure()
+    {
+        $this->get(/version);
+        $this->seeJsonStructure([
+            api_version,
+            min_client_version, php_version,
+            lumen_version
+        ]);
+    }
+
+    public function testVersionEndpointDoesNotRequireAuth()
+    {
+        $this->get(/version);
+        $this->seeStatusCode(200);
+    }
+}
+

--- a/tests/Feature/VersionEndpointTest.php
+++ b/tests/Feature/VersionEndpointTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+
+class VersionCheckTest extends TestCase
+{
+    public function testVersionConfigExists()
+    {
+        $this->assertNotNull(config('version.version'));
+        $this->assertNotNull(config('version.min_client_version'));
+    }
+}
+


### PR DESCRIPTION
Adiciona endpoint GET /version e configuração correspondente para comunicar versão da API e versão mínima compatível para clientes desktop/web.

**Mudanças:**
- Criação de config/version.php com  e 
- Criação de VersionController com método index() retornando JSON
- Adição de rota GET /version em web.php (acessível publicamente)
- Teste unitário para validar existencia da configuração

**Impacto:**
- Clientes (desktop/web) podem chamar {"error":"Idioma 'version' n\u00e3o encontrado."} e verificar compatibilidade antes de fazer requests para rotas quebraveis entre versoes