### PR TITLE
feat: env validation no bootstrap — falha rapido se vars obrigatorias nao definidas

### DIFF
--- a/app/Helpers/EnvValidator.php
+++ b/app/Helpers/EnvValidator.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Helpers;
+
+/**
+ * Validates required environment variables at application startup.
+ *
+ * Call EnvValidator::check() in bootstrap/app.php after config loads.
+ * Throws RuntimeException with a clear message listing missing vars.
+ */
+class EnvValidator
+{
+    /**
+     * Environment variables required in ALL environments.
+     */
+    private static array $required = [
+        'APP_KEY',
+        'JWT_SECRET',
+    ];
+
+    /**
+     * Environment variables required in production only.
+     */
+    private static array $requiredProduction = [
+        'API_TOKEN',
+    ];
+
+    /**
+     * Validate that required env vars are set and non-empty.
+     *
+     * @throws \RuntimeException if any required variable is missing
+     */
+    public static function check(): void
+    {
+        $missing = [];
+
+        foreach (self::$required as $var) {
+            if (!env($var)) {
+                $missing[] = $var;
+            }
+        }
+
+        // Production-only checks
+        if (app()->environment('production')) {
+            foreach (self::$requiredProduction as $var) {
+                if (!env($var)) {
+                    $missing[] = $var . ' (production)';
+                }
+            }
+        }
+
+        if (!empty($missing)) {
+            throw new \RuntimeException(
+                'Variáveis de ambiente obrigatórias não definidas: ' . implode(', ', $missing)
+                . '. Verifique o arquivo .env.'
+            );
+        }
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -64,6 +64,9 @@ $app->configure('auth');
 $app->configure('api');
 $app->configure('files');
 
+/* Validate required environment variables after config loads */
+App\Helpers\EnvValidator::check();
+
 /*
 |--------------------------------------------------------------------------
 | Register Middleware

--- a/tests/Unit/EnvValidatorTest.php
+++ b/tests/Unit/EnvValidatorTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+
+class EnvValidatorTest extends TestCase
+{
+    public function testValidatorHasRequiredVars()
+    {
+        $validator = new \ReflectionClass(\App\Helpers\EnvValidator::class);
+        $required = $validator->getProperty('required');
+        $required->setAccessible(true);
+        $values = $required->getValue();
+
+        $this->assertContains('APP_KEY', $values);
+        $this->assertContains('JWT_SECRET', $values);
+    }
+
+    public function testValidatorHasProductionOnlyVars()
+    {
+        $validator = new \ReflectionClass(\App\Helpers\EnvValidator::class);
+        $prod = $validator->getProperty('requiredProduction');
+        $prod->setAccessible(true);
+        $values = $prod->getValue();
+
+        $this->assertContains('API_TOKEN', $values);
+    }
+
+    public function testCheckMethodExists()
+    {
+        $this->assertTrue(method_exists(\App\Helpers\EnvValidator::class, 'check'));
+    }
+
+    public function testValidatorAcceptsAllVarsSet()
+    {
+        // In test env, APP_KEY and JWT_SECRET are set via phpunit.xml
+        // This should not throw
+        \App\Helpers\EnvValidator::check();
+        $this->assertTrue(true); // Reached = no exception
+    }
+}


### PR DESCRIPTION
Validacao de variaveis de ambiente no bootstrap da aplicacao.

**Problema:** Se APP_KEY ou JWT_SECRET nao estao definidos no .env, a API falha com erros cripticos (erro no JWT, cipher, etc.) em vez de dar uma mensagem clara.

**Solucao:** Adiciona EnvValidator::check() no bootstrap apos config load.

**Detalhes:**
- Vars obrigatorias (todos os ambientes): APP_KEY, JWT_SECRET
- Vars obrigatorias (producao): API_TOKEN
- RuntimeException com mensagem clara listando vars faltantes
- Em vez de falhar silenciosamente, falha rapido (fail-fast)
- 4 testes unitarios

31/31 testes passando.