### PR TITLE
fix: StreamedResponse 500 em downloads de arquivos (covers, mp3, database)

### DIFF
--- a/app/Http/Middleware/RateLimitMiddleware.php
+++ b/app/Http/Middleware/RateLimitMiddleware.php
@@ -32,14 +32,16 @@ class RateLimitMiddleware
         if ($attempts >= $maxRequests) {
             $retryAfter = Cache::get("{$key}:reset_at", Carbon::now()->addSeconds($decaySeconds)->timestamp);
 
-            return response()->json([
+            $response = response()->json([
                 'error' => 'Too Many Requests',
                 'message' => 'Limite de requisições excedido. Tente novamente em breve.',
                 'retry_after' => $retryAfter - Carbon::now()->timestamp,
-            ], 429)
-                ->header('X-RateLimit-Limit', (string) $maxRequests)
-                ->header('X-RateLimit-Remaining', '0')
-                ->header('Retry-After', (string) ($retryAfter - Carbon::now()->timestamp));
+            ], 429);
+            $response->headers->set('X-RateLimit-Limit', (string) $maxRequests);
+            $response->headers->set('X-RateLimit-Remaining', '0');
+            $response->headers->set('Retry-After', (string) ($retryAfter - Carbon::now()->timestamp));
+
+            return $response;
         }
 
         Cache::put($key, $attempts + 1, $decaySeconds);
@@ -53,8 +55,11 @@ class RateLimitMiddleware
 
         $response = $next($request);
 
-        return $response
-            ->header('X-RateLimit-Limit', (string) $maxRequests)
-            ->header('X-RateLimit-Remaining', (string) max($remaining, 0));
+        // StreamedResponse não tem ->header() (Symfony 6.4+).
+        // Usa ->headers->set() que funciona em qualquer Response.
+        $response->headers->set('X-RateLimit-Limit', (string) $maxRequests);
+        $response->headers->set('X-RateLimit-Remaining', (string) max($remaining, 0));
+
+        return $response;
     }
 }


### PR DESCRIPTION
## Problema

Todas as rotas de download de arquivos (`/file/{path}`) estavam retornando erro 500:

```json
{"error":"Call to undefined method Symfony\\Component\\HttpFoundation\\StreamedResponse::header()","code":500}
```

Isso afetava:
- Imagens de cover das musicas
- Arquivos de audio (mp3)
- Download do banco de dados
- Causava `NotSupportedError` de audio no Desktop app (recebia JSON de erro ao inves do mp3)

## Causa raiz

O `RateLimitMiddleware` usava `->header()` para adicionar headers de rate limiting na response. `StreamedResponse` (retornada pelo `FileController::open`) nao tem `->header()` no Symfony 6.4+.

## Fix

Substituir `->header()` por `->headers->set()` que funciona em qualquer tipo de Response.

```diff
- return $response
-     ->header('X-RateLimit-Limit', (string) $maxRequests)
-     ->header('X-RateLimit-Remaining', (string) max($remaining, 0));
+ $response->headers->set('X-RateLimit-Limit', (string) $maxRequests);
+ $response->headers->set('X-RateLimit-Remaining', (string) max($remaining, 0));
+ return $response;
```

## Impacto

Merge urgente — bloqueia TODOS os downloads na API em producao.